### PR TITLE
fix: Allow setting 0 for `soft_delete_retention_days`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -328,8 +328,8 @@ variable "soft_delete_retention_days" {
   description = "The number of days that items are retained before being permanently deleted. Default is 7 days."
 
   validation {
-    error_message = "Must be a positive integer"
-    condition     = var.soft_delete_retention_days != null ? var.soft_delete_retention_days > 0 && floor(var.soft_delete_retention_days) == var.soft_delete_retention_days : true
+    error_message = "Must be a positive integer or 0"
+    condition     = var.soft_delete_retention_days != null ? var.soft_delete_retention_days >= 0 && floor(var.soft_delete_retention_days) == var.soft_delete_retention_days : true
   }
 }
 


### PR DESCRIPTION
## Description

Allow 0 to be set for the soft delete retention as previously the module only allowed for setting `null` when it was not required.

Setting `null` however, produces a state drift on every apply as the Azure API reports the retention days as `0` not `null`.

Fixes #20 

<!--
>Thank you for your contribution !
> Please include a summary of the change and which issue is fixed.
> Please also include the context.
> List any dependencies that are required for this change.

Fixes #123
Closes #456
-->

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
