### PR TITLE
[INFRA-7898] expose role_assignment_name_use_random_uuid

### DIFF
--- a/main.interfaces.tf
+++ b/main.interfaces.tf
@@ -11,5 +11,6 @@ module "avm_interfaces" {
   private_endpoints_manage_dns_zone_group = var.private_endpoints_manage_dns_zone_group
   private_endpoints_scope                 = "${var.resource_group_resource_id}/providers/Microsoft.AppConfiguration/configurationStores/${var.name}"
   role_assignment_definition_scope        = var.resource_group_resource_id
+  role_assignment_name_use_random_uuid    = var.role_assignment_name_use_random_uuid
   role_assignments                        = var.role_assignments
 }

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,18 @@ DESCRIPTION
   nullable    = false
 }
 
+variable "role_assignment_name_use_random_uuid" {
+  type        = bool
+  default     = false
+  nullable    = false
+  description = <<DESCRIPTION
+A control to use a random UUID for the role assignment name.
+If set to false, the name will be a deterministic UUID based on the principal ID and role definition resource ID,
+though this can cause issues with duplicate UUIDs as the scope of the role assignment is not taken into account.
+Set to true to avoid UUID collisions when the same principal and role are assigned across multiple stores.
+DESCRIPTION
+}
+
 variable "role_assignments" {
   type = map(object({
     role_definition_id_or_name             = string


### PR DESCRIPTION
## Summary

https://mews.atlassian.net/browse/INFRA-7898

- Exposes `role_assignment_name_use_random_uuid` as a top-level module input and passes it through to the `avm-utl-interfaces` sub-module in `main.interfaces.tf`
- This allows consumers to opt into random UUID generation for role assignment names, avoiding deterministic UUID collisions when multiple App Configuration stores assign the same principal to the same role

## Problem

The `avm-utl-interfaces` sub-module generates deterministic UUIDs for role assignments using `uuidv5("url", principal_id + role_definition_id)` — the parent resource scope is **not** included in the hash. This causes `RoleAssignmentUpdateNotPermitted` errors when two different App Configuration stores in the same subscription have role assignments with the same principal and role definition, because the UUID collides.

The sub-module already has a `role_assignment_name_use_random_uuid` variable to fix this, but the top-level App Configuration module never exposed or passed it through.

## Changes

- **`variables.tf`** — Added `role_assignment_name_use_random_uuid` variable (bool, default `false`)
- **`main.interfaces.tf`** — Pass `role_assignment_name_use_random_uuid` to the `avm_interfaces` module call

